### PR TITLE
Page redesign

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bdecd412c161a96db19fa68b2d400525",
+    "hash": "97e6c21a1af10e81762a5dc0b9ac772c",
     "packages": [
         {
             "name": "acquia/http-hmac-php",

--- a/views/e911.html
+++ b/views/e911.html
@@ -1,110 +1,124 @@
-<h2 class="e911">University of South Florida 911 and E911 Disclosure, Notice, and Acknowledgement ("Acknowledgement")</h2>
-<div id="section1" class="container-fluid">
+<div id="section1" class="container">
     <div class="row">
-        <div class="col-md-12 e911">
-            You have been identified as a user of the Voice Over Internet Protocol ("VoIP") telephone service offered by the University of South Florida ("USF") (hereinafter "USF VoIP Service").
-            The Federal Communications Commission ("FCC") has regulations that require USF, along with all VoIP service providers, to inform its users of any differences between the 911 and E911 
-            access capabilites available with USF's Service ("VoIP 911 and E911 Service") as compared to the 911 and E911 access capabilites available with traditional wireless telephone service.
-            It is important that you understand how these differences affect your ability to access 911 and E911 services. 
-            In addition to the notice requirements, the FCC regulations require USF to obtain and keep a record on file showing that you have received the required notice and understand the 
-            information contained in this Acknowledgement.
-            USF asks that you carefully read this Acknowledgement.
-            If you have any questions or concerns about the information contained in this Acknowledgement, or if you do not understand anything discussed in this Acknowledgement, 
-            please contact USF Information Technology ("USF IT") at <a href="mailto:help@usf.edu">help@usf.edu</a>.
-            <br>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12 e911">
+      <div class="text-center">
+        <h2>University of South Florida 911 and E911 Disclosure, Notice, and Acknowledgement ("Acknowledgement")</h2>
+      </div>
+      <div class="col-md-12">
+        <p>
+          You have been identified as a user of the Voice Over Internet Protocol ("VoIP") telephone service offered by the University of South Florida ("USF") (hereinafter "USF VoIP Service").
+          The Federal Communications Commission ("FCC") has regulations that require USF, along with all VoIP service providers, to inform its users of any differences between the 911 and E911
+          access capabilites available with USF's Service ("VoIP 911 and E911 Service") as compared to the 911 and E911 access capabilites available with traditional wireless telephone service.
+          It is important that you understand how these differences affect your ability to access 911 and E911 services.
+          In addition to the notice requirements, the FCC regulations require USF to obtain and keep a record on file showing that you have received the required notice and understand the
+          information contained in this Acknowledgement.
+          USF asks that you carefully read this Acknowledgement.
+          If you have any questions or concerns about the information contained in this Acknowledgement, or if you do not understand anything discussed in this Acknowledgement,
+          please contact USF Information Technology ("USF IT") at <a href="mailto:help@usf.edu">help@usf.edu</a>.
+        </p>
+        <p>
             Access to VoIP 911 and E911 Services can be limited and different from traditional wireline telephone 911 services in several important ways.
             Traditional 911 services automatically route your calls to a 911 dispatcher using special answering facilities at the local Public Safety Answering Point ("PSAP") for your geographic location.
-            Traditional E911 services automatically provide to the PSAPs the calling party's call-back number and location. 
-            If you are located in an areal where the emergency center does not support E911 (i.e., is not capable of simultaneously receiving your telephone number and address), you likely have basic 911 service.
-            <br>
-        </div>
-    </div>
+            Traditional E911 services automatically provide to the PSAPs the calling party's call-back number and location.
+            If you are located in an area where the emergency center does not support E911 (i.e., is not capable of simultaneously receiving your telephone number and address), you likely have basic 911 service.
+        </p>
+      </div>
 </div>
-<div id="section2" class="container-fluid e911">
+<hr />
+<div id="section2" class="container">
     <div class="row">
         <div class="col-md-12">
-            Your use of USF's VoIP Services is subject to the following VoIP 911 and E911 Service limitations (please click "<mark>I Acknowledge</mark>" next to each limitation):
+            <h4>Your use of USF's VoIP Services is subject to the following VoIP 911 and E911 Service limitations <small>(please click <mark>I Acknowledge</mark> next to each limitation)</small></h4>
         </div>
     </div>
-    <br>
-    <div class="row panel panel-default">
-        <div class="col-md-1">
-            <span>
-                <button type="button" class="btn btn-sm" ng-click="acknowledge(1)" ng-class="{'btn-primary': isAcknowledged(1) === false, 'btn-default': isAcknowledged(1) === true}">I Acknowledge</button>                
-            </span>
-        </div>
-        <div class="col-md-11">
-            EMERGENCY PERSONNEL MAY NOT BE ABLE TO IDENTIFY YOUR PHONE NUMBER IN ORDER TO CALL YOU BACK. PSAP and emergency personnel may not be able to identify your phone number in order to call you back 
-            if the call cannot be completed, is dropped or disconnected and/or if the USF VoIP Services or VoIP 911 or E911 Services is not operational for any reason.
-        </div>
-    </div>
-    <div class="row panel panel-default">
-        <div class="col-md-1">
-            <button type="button" class="btn btn-primary btn-sm" ng-click="acknowledge(2)">I Acknowledge</button>
-        </div>
-        <div class="col-md-11">
-            USF'S VOIP 911 AND E911 SERVICE CALLS MAY BE DELAYED OR DROPPED DUE TO NETWORK ARCHITECTURE OR LIMITATIONS. Due to technical constraints, there is a greater possibility of network congestion and/or 
-            reduced speed in the routing of a 911 call made utilizing your equipment as compared to traditional 911 dialing over traditional public switched telephone networks.
-        </div>
-    </div>
-    <div class="row panel panel-default">
-        <div class="col-md-1">
-            <button type="button" class="btn btn-primary btn-sm"  ng-click="acknowledge(3)">I Acknowledge</button>
-        </div>
-        <div class="col-md-11">
-            VOIP 911 AND E911 SERVICE MAY NOT OPERATE DURING A POWER OUTAGE. Should there be an interruption in the power at your physical location or to the infrastructure supporting USF's VoIP Services, 
-            the VoIP 911 and E911 Service, will not function until power is restored and your equipment is reset, as required.
-        </div>
-    </div>
-    <div class="row panel panel-default">
-        <div class="col-md-1">
-            <button type="button" class="btn btn-primary btn-sm" ng-click="acknowledge(4)">I Acknowledge</button>
-        </div>
-        <div class="col-md-11">
-            USF'S VOIP 911 AND E911 SERVICE WILL NOT OPERATE IF YOUR NETWORK/INTERNET CONNECTION IS DISRUPTED. VoIP technology is provided through properly functioning network and/or Internet connectivity. 
-            Therefore, service outages, interruptions, network congestion or degradation, or termination or suspension for any reason, of network and/or Internet connectivity by your mobile wireless provider, 
-            local Internet service provider ("ISP"), or USF will prevent you from accessing USF's VoIP Service, including VoIP 911 and E911 Service.
-        </div>
-    </div>
-    <div class="row panel panel-default">
-        <div class="col-md-1 col-centered">
-            <button type="button" class="btn btn-primary btn-sm " ng-click="acknowledge(5)">I Acknowledge</button>
-        </div>
-        <div class="col-md-11">
-            USF'S VOIP 911 AND E911 SERVICE CALLS MAY NOT COMPLETE OR MAY BE ROUTED TO EMERGENCY PERSONNEL WHO WILL NOT BE ABLE TO ASSIST IF YOU DISABLE, DAMAGE, MOVE THE EQUIPMENT TO A LOCATION OTHER THAN THE REGISTERED
-            BUSINESS ADDRESS ASSIGNED BY USF, OR ACCESS THE SERVICES FROM A REMOTE LOCATION, THROUGH A SOFTPHONE, OR ON A MOBILE DEVICE. VoIP 911 and E911 Service does not function if you move your equipment to 
-            a different street address or physical location (other than the registered address assigned by USF), or access it through a softphone (a software application that allows you to make telephone calls 
-            via the Internet), wireless, or remote network connection, or through a mobile devices. Failure to access the USF VoIP service from your registered business address may result in any 911 call you make 
-            being routed to the incorrect local emergency service provider and emergency personnel being dispatched to the incorrect location.
-        </div>
-    </div>    
-</div>
-<div id="section3" class="container-fluid">
     <div class="row">
-        <div class="col-md-12 e911">
-            It is important to understand that while USF makes commercially reasonable efforts to provide reliable access to 911 and E911 to users of the USF VoIP service, VoIP services have inherent limitations 
+      <div class="panel panel-default col-md-offset-1 col-md-10">
+        <div class="panel-body clearfix">
+          <strong>Emergency personnel may not be able to identify your phone number in order to call you back.</strong> PSAP and emergency personnel may not be able to identify your phone number in order to call you back
+          if the call cannot be completed, is dropped or disconnected and/or if the USF VoIP Services or VoIP 911 or E911 Services is not operational for any reason.
+          <br />
+          <div class="pull-right">
+              <button type="button" class="btn btn-sm" ng-click="acknowledge(1)" ng-class="{'btn-primary': isAcknowledged(1) === false, 'btn-default': isAcknowledged(1) === true}">I Acknowledge</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="well col-md-offset-1 col-md-10">
+        <div class="clearfix">
+          <strong>USF'S VoIP 911 and E911 service calls may be delayed or dropped due to network architecture or limitations.</strong> Due to technical constraints, there is a greater possibility of network congestion and/or
+          reduced speed in the routing of a 911 call made utilizing your equipment as compared to traditional 911 dialing over traditional public switched telephone networks.
+          <br />
+          <div class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm" disabled="disabled" ng-click="acknowledge(2)">I Acknowledge</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="well col-md-offset-1 col-md-10">
+        <div class="clearfix">
+          <strong>VoIP 911 AND E911 service may not operate during a power outage.</strong> Should there be an interruption in the power at your physical location or to the infrastructure supporting USF's VoIP Services,
+          the VoIP 911 and E911 Service, will not function until power is restored and your equipment is reset, as required.
+          <br />
+          <div class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm"  disabled="disabled" ng-click="acknowledge(3)">I Acknowledge</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="well col-md-offset-1 col-md-10">
+        <div class="clearfix">
+          <strong>USF'S VoIP 911 and E911 service will not operate if your network/Internet connection is disrupted.</strong> VoIP technology is provided through properly functioning network and/or Internet connectivity.
+          Therefore, service outages, interruptions, network congestion or degradation, or termination or suspension for any reason, of network and/or Internet connectivity by your mobile wireless provider,
+          local Internet service provider ("ISP"), or USF will prevent you from accessing USF's VoIP Service, including VoIP 911 and E911 Service.
+          <br />
+          <div class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm" disabled="disabled" ng-click="acknowledge(4)">I Acknowledge</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="well col-md-offset-1 col-md-10">
+        <div class="clearfix">
+          <strong>USF'S VoIP 911 and E911 service calls may not complete or may be routed to emergency personnel who will not be able to assist if you disable, damage, move the equipment to a location other than the registered
+          business address assigned by USF, or access the services from a remote location, through a softphone, or on a mobile device.</strong> VoIP 911 and E911 Service does not function if you move your equipment to
+          a different street address or physical location (other than the registered address assigned by USF), or access it through a softphone (a software application that allows you to make telephone calls
+          via the Internet), wireless, or remote network connection, or through a mobile devices. Failure to access the USF VoIP service from your registered business address may result in any 911 call you make
+          being routed to the incorrect local emergency service provider and emergency personnel being dispatched to the incorrect location.
+          <br />
+          <span class="pull-right">
+            <button type="button" class="btn btn-primary btn-sm" disabled="disabled" ng-click="acknowledge(5)">I Acknowledge</button>
+          </span>
+        </div>
+      </div>
+    </div>
+</div>
+<hr />
+<div id="section3" class="container">
+    <div class="row">
+        <div class="col-md-12">
+          <p>
+            It is important to understand that while USF makes commercially reasonable efforts to provide reliable access to 911 and E911 to users of the USF VoIP service, VoIP services have inherent limitations
             due to the networks, systems, and technology relied upon to implement such services as well as the mobile access capabilities of such services, all of which are beyond USF's control.
-            <br>
+          </p>
+          <p>
+            <strong>USF does not have any control over whether, or the manner in which, 911 calls using USF's VoIP service and the VoIP 911 and E911 service are answered or addressed by any local emergency response center.</strong>
+          </p>
+          <p>
+            <strong>USF disclaims all responsibility for the conduct of local emergency response centers and the National Emergency Response Calling Center.</strong>
+          </p>
         </div>
     </div>
+  <hr />
     <div class="row">
-        <div class="col-md-12 e911">
-            USF DOES NOT HAVE ANY CONTROL OVER WHETHER, OR THE MANNER IN WHICH, 911 CALLS USING THE USF'S VOIP SERVICE AND THE VOIP 911 AND E911 SERVICE ARE ANSWERED OR ADDRESSED BY ANY LOCAL EMERGENCY RESPONSE CENTER. 
-            USF DISCLAIMS ALL RESPONSIBILITY FOR THE CONDUCT OF LOCAL EMERGENCY RESPONSE CENTERS AND THE NATIONAL EMERGENCY RESPONSE CALLING CENTER.
-            <br>
+        <div class="col-md-12">
+            <br />
+            <strong>By completing and submitting this form, you certify that you have received and understand the information contained in this Acknowledgement.</strong>
+            <br />
+            <button type="button" ng-click="e911sign()" class="btn btn-primary btn-lg btn-block" disabled="disabled">Submit</button>
         </div>
+      </div>
     </div>
-    <div class="row">
-        <div class="col-md-12 e911">
-            <strong>By completing and submitting the Acknowledgement, you certify that you have received and understand the information contained in this Acknowledgement.</strong>
-            <br>
-        </div>
-    </div>
-</div>
-<div id="submit" class="container-fluid e911">
-    <button type="button" ng-click="e911sign()" class="btn btn-primary btn-lg btn-block">Submit</button>
-</div>
+    <br />


### PR DESCRIPTION
Removed all custom CSS and formatted the page using only Bootstrap elements.  Since the vertical alignment wasn't working, I took a different tack on the page design - moving the ack buttons to the right and below the text.